### PR TITLE
Don't attempt to re-lock Pipfile in Docker

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 ADD src /code/
 WORKDIR /code
-RUN pip install pipenv && pipenv install --system
+RUN pip install pipenv && pipenv install --ignore-pipfile --system
 
 CMD gunicorn potatostore.wsgi
 

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -5,6 +5,6 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 ADD src /code/
 WORKDIR /code
-RUN pip install pipenv && pipenv install --system
+RUN pip install pipenv && pipenv install --ignore-pipfile --system
 
 RUN python3 /code/manage.py test


### PR DESCRIPTION
A bug in Pipenv made it try to use `/python` instead of
the proper path when generating the lockfile. It is also
good if we can control when packages are upgraded, so we're
not suddenly bit by new pip packages being available.